### PR TITLE
Soporte para bloques matemáticos

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,7 @@ GEM
     ffi (1.15.5)
     forwardable (1.3.3)
     forwardable-extended (2.6.0)
+    google-protobuf (3.24.2-arm64-darwin)
     google-protobuf (3.24.2-x86_64-darwin)
     google-protobuf (3.24.2-x86_64-linux)
     http_parser.rb (0.8.0)
@@ -82,6 +83,8 @@ GEM
     mercenary (0.4.0)
     namae (1.2.0)
       racc (~> 1.7)
+    nokogiri (1.18.8-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.18.8-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.8-x86_64-linux-gnu)
@@ -101,6 +104,8 @@ GEM
     rexml (3.2.6)
     rouge (4.1.3)
     safe_yaml (1.0.5)
+    sass-embedded (1.66.1-arm64-darwin)
+      google-protobuf (~> 3.23)
     sass-embedded (1.66.1-x86_64-darwin)
       google-protobuf (~> 3.23)
     sass-embedded (1.66.1-x86_64-linux-gnu)
@@ -117,6 +122,7 @@ GEM
     webrick (1.8.1)
 
 PLATFORMS
+  arm64-darwin-24
   x86_64-darwin-22
   x86_64-darwin-23
   x86_64-linux

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # ASOESEM
 
-Este es el sitio oficial del la Asociación de Estudiantes de la carrera de la Enseñanza de las Matemáticas de la UNED Costa Rica.
+Este es el sitio oficial del la [Asociación de Estudiantes de la carrera de la Enseñanza de las Matemáticas de la UNED](mailto:asoesem@uned.ac.cr) Costa Rica.
 

--- a/_includes/main.scss
+++ b/_includes/main.scss
@@ -110,3 +110,9 @@
 @import '4-layouts/authors';
 /* >>>>>>>>>>>>>> :: 4.3-Tags Page <<<<<<<<<<<<<<< */
 @import '4-layouts/tags-page';
+
+/* =======================
+:: 5-Theorems
+======================= */
+/* >>>>>>>>>>>>>> :: 5.1-Theorems <<<<<<<<<<<<<<< */
+@import '5-theorems/theorems';

--- a/_plugins/math_block_tags.rb
+++ b/_plugins/math_block_tags.rb
@@ -1,7 +1,7 @@
-require 'cgi' # For HTML escaping
-require 'jekyll' # Ensure Jekyll is loaded
+require 'cgi'
+require 'jekyll'
 
-# This plugin defines custom Liquid tags for Jekyll to create and reference math blocks.
+# Este plugin define etiquetas personalizadas para crear referenciar bloques matemáticos.
 module Jekyll
   # Stores display names for block types, matching your SCSS.
   BLOCK_TYPE_NAMES = {
@@ -102,7 +102,7 @@ module Jekyll
   end
 
   # This tag is used to create a link to a math block by its label.
-  class MathRefTag < Liquid::Tag
+  class MathBlockRefTag < Liquid::Tag
     def initialize(tag_name, markup, tokens)
       super
       @label_arg = markup.strip # This is the 'label-id' from {% math_ref label-id %}
@@ -136,5 +136,5 @@ module Jekyll
     Liquid::Template.register_tag(block_type, MathBlockTag)
   end
 
-  Liquid::Template.register_tag('math_ref', MathRefTag)
+  Liquid::Template.register_tag('block_ref', MathBlockRefTag)
 end

--- a/_plugins/math_block_tags.rb
+++ b/_plugins/math_block_tags.rb
@@ -11,7 +11,7 @@ module Jekyll
     'lemma'      => 'Lema',
     'axiom'      => 'Axioma',
     'definition' => 'Definición',
-    'proof'      => 'Prueba' # Spanish for Proof
+    'proof'      => 'Demostración'
   }.freeze
 
   class MathBlockTag < Liquid::Block
@@ -63,7 +63,7 @@ module Jekyll
           block_title_str = escaped_user_title
         else
           # Default proof title.
-          block_title_str = "#{display_block_name}." # e.g., "Prueba."
+          block_title_str = "#{display_block_name}" # e.g., "Prueba."
         end
       else
         # For theorem, definition, axiom, etc.
@@ -73,7 +73,7 @@ module Jekyll
           block_title_str = "#{base_name_and_number}: #{escaped_user_title}" # e.g., "Teorema 1: Título Opcional"
         else
           # No user-provided title, use a period.
-          block_title_str = "#{base_name_and_number}." # e.g., "Teorema 1."
+          block_title_str = "#{base_name_and_number}" # e.g., "Teorema 1."
         end
       end
 

--- a/_plugins/math_block_tags.rb
+++ b/_plugins/math_block_tags.rb
@@ -1,4 +1,19 @@
-# ...existing code...
+require 'cgi' # For HTML escaping
+require 'jekyll' # Ensure Jekyll is loaded
+
+# This plugin defines custom Liquid tags for Jekyll to create and reference math blocks.
+module Jekyll
+  # Stores display names for block types, matching your SCSS.
+  BLOCK_TYPE_NAMES = {
+    'theorem'    => 'Teorema',
+    'postulate'  => 'Postulado',
+    'corollary'  => 'Corolario',
+    'lemma'      => 'Lema',
+    'axiom'      => 'Axioma',
+    'definition' => 'Definición',
+    'proof'      => 'Prueba' # Spanish for Proof
+  }.freeze
+
   class MathBlockTag < Liquid::Block
     def initialize(tag_name, markup, tokens)
       super
@@ -86,10 +101,7 @@
     end
   end
 
-# ... MathRefTag class and registration code remain the same ...
-# ... (rest of your _plugins/math_block_tags.rb file) ...
-# filepath: /Users/edalorzo/Sandbox/asoesem.github.io/_plugins/math_block_tags.rb
-# ...existing code...
+  # This tag is used to create a link to a math block by its label.
   class MathRefTag < Liquid::Tag
     def initialize(tag_name, markup, tokens)
       super

--- a/_plugins/math_block_tags.rb
+++ b/_plugins/math_block_tags.rb
@@ -3,7 +3,7 @@ require 'jekyll'
 
 # Este plugin define etiquetas personalizadas para crear referenciar bloques matemáticos.
 module Jekyll
-  # Stores display names for block types, matching your SCSS.
+  # Almacena nombres para mostrar para los tipos de bloques, que coinciden con su SCSS.
   BLOCK_TYPE_NAMES = {
     'theorem'    => 'Teorema',
     'postulate'  => 'Postulado',
@@ -20,28 +20,28 @@ module Jekyll
       @markup = markup.strip
       @block_type = tag_name # 'theorem', 'definition', etc.
 
-      # Regex to capture title (must be quoted) and label (can be unquoted)
+      # Expresión regular para capturar el título (debe estar entre comillas) y la etiqueta (puede no estar entre comillas)
       @title_param = @markup.match(/title=(?:"([^"]*)"|'([^']*)')/i)&.captures&.compact&.first
       @label_param = @markup.match(/label=(?:"([^"]*)"|'([^']*)'|([a-zA-Z0-9_-]+))/i)&.captures&.compact&.first
     end
 
     def render(context)
       site = context.registers[:site]
-      page = context.environments.first['page'] # Get the current page/post object
+      page = context.environments.first['page'] # Obtener el objeto de la página/artículo actual
       converter = site.find_converter_instance(Jekyll::Converters::Markdown)
 
-      page['math_block_counters'] ||= Hash.new(0)
-      site.config['math_block_references'] ||= {}
+      page['block_counters'] ||= Hash.new(0)
+      site.config['block_references'] ||= {}
 
-      current_number = (page['math_block_counters'][@block_type] += 1)
+      current_number = (page['block_counters'][@block_type] += 1)
       display_block_name = BLOCK_TYPE_NAMES[@block_type] || @block_type.capitalize
 
       if @label_param && !@label_param.strip.empty?
         clean_label = @label_param.strip
-        if site.config['math_block_references'].key?(clean_label)
-          Jekyll.logger.warn "Math Label Warning:", "Label '#{clean_label}' is already in use. Labels should be unique across the site for math_ref to work reliably."
+        if site.config['block_references'].key?(clean_label)
+          Jekyll.logger.warn "Advertencia de etiqueta:", "La etiqueta '#{clean_label}' ya está en uso."
         end
-        site.config['math_block_references'][clean_label] = {
+        site.config['block_references'][clean_label] = {
           'type_key'    => @block_type,
           'name'        => display_block_name,
           'number'      => current_number,
@@ -59,20 +59,16 @@ module Jekyll
 
       if @block_type == "proof"
         if !escaped_user_title.empty?
-          # User-provided title for a proof is usually the full subject.
           block_title_str = escaped_user_title
-        else
-          # Default proof title.
-          block_title_str = "#{display_block_name}" # e.g., "Prueba."
+        else          
+          block_title_str = "#{display_block_name}"
         end
       else
-        # For theorem, definition, axiom, etc.
+        # Para teorema, definición, axioma, etc.
         base_name_and_number = "#{display_block_name} #{current_number}"
         if !escaped_user_title.empty?
-          # Has a user-provided title, use a colon.
           block_title_str = "#{base_name_and_number}: #{escaped_user_title}" # e.g., "Teorema 1: Título Opcional"
         else
-          # No user-provided title, use a period.
           block_title_str = "#{base_name_and_number}" # e.g., "Teorema 1."
         end
       end
@@ -101,22 +97,22 @@ module Jekyll
     end
   end
 
-  # This tag is used to create a link to a math block by its label.
+  # Esta etiqueta se utiliza para crear un enlace a un bloque de matemáticas mediante su etiqueta.
   class MathBlockRefTag < Liquid::Tag
     def initialize(tag_name, markup, tokens)
       super
-      @label_arg = markup.strip # This is the 'label-id' from {% math_ref label-id %}
+      @label_arg = markup.strip # Este es el 'label-id' de {% block_ref label-id %}
       if @label_arg.empty?
-        raise SyntaxError, "No label provided for math_ref tag. Usage: {% math_ref your-label %}"
+        raise SyntaxError, "No se proveyó etiqueta para el block_ref. Uso: {% block_ref tu-etiqueta %}"
       end
       unless @label_arg.match?(/^[a-zA-Z0-9_-]+$/)
-        raise SyntaxError, "Invalid characters in label for math_ref tag: '#{@label_arg}'. Use letters, numbers, hyphens, or underscores."
+        raise SyntaxError, "Caracter inválido en la etiqueta para block_ref tag: '#{@label_arg}'. Utilice letras, números, guiones o guiones bajos."
       end
     end
 
     def render(context)
       site = context.registers[:site]
-      references = site.config['math_block_references']
+      references = site.config['block_references']
 
       if references && references.key?(@label_arg)
         ref_data = references[@label_arg]
@@ -126,7 +122,7 @@ module Jekyll
 
         "<a href=\"##{href_id}\">#{CGI.escapeHTML(link_text)}</a>"
       else
-        Jekyll.logger.warn "Math Reference Warning:", "Label '#{@label_arg}' not found for math_ref tag."
+        Jekyll.logger.warn "Advertencia de referencia de bloque:", "No se encontró la etiqueta '#{@label_arg}' para block_ref tag."
         "[Referencia a '#{CGI.escapeHTML(@label_arg)}' no encontrada]"
       end
     end

--- a/_plugins/math_block_tags.rb
+++ b/_plugins/math_block_tags.rb
@@ -1,0 +1,57 @@
+# filepath: /_plugins/math_block_tags.rb
+require 'cgi' # For HTML escaping
+
+module Jekyll
+  class MathBlockTag < Liquid::Block
+    def initialize(tag_name, markup, tokens)
+      super
+      @markup = markup.strip
+      @block_type = tag_name # 'theorem', 'definition', etc.
+
+      # Regex to capture title and label, supporting various quote styles or no quotes for label
+      # title="Anything here", title='Anything here'
+      # label=my-label, label="my-label", label='my-label'
+      @title = @markup.match(/title=(?:"([^"]*)"|'([^']*)'|(\S+))/i)&.captures&.compact&.first
+      @label = @markup.match(/label=(?:"([^"]*)"|'([^']*)'|([a-zA-Z0-9_-]+))/i)&.captures&.compact&.first
+    end
+
+    def render(context)
+      site = context.registers[:site]
+      converter = site.find_converter_instance(Jekyll::Converters::Markdown)
+      
+      # Render the content within the block using Liquid, then convert to HTML using Markdown
+      raw_block_content = super(context) # Renders content between {% tag %} and {% endtag %}
+      processed_content = converter.convert(raw_block_content.strip).strip
+
+      title_span_content = @title && !@title.strip.empty? ? CGI.escapeHTML(@title.strip) : ""
+      title_span = "<span class=\"math-block-title\">#{title_span_content}</span>"
+
+      id_attribute = ""
+      if @label && !@label.strip.empty?
+        id_attribute = " id=\"#{CGI.escapeHTML(@label.strip)}\""
+      end
+      
+      css_class = "math-block #{@block_type}"
+      if @block_type == "proof" && @title && !@title.strip.empty?
+        css_class += " has-subject"
+      end
+
+      # Construct the HTML output
+      output = <<~HTML
+        <div class="#{css_class}"#{id_attribute}>
+          #{title_span}
+          <div class="math-block-body">
+            #{processed_content}
+          </div>
+        </div>
+      HTML
+      output.strip
+    end
+  end
+
+  # Register each specific math block type
+  # For each type, we just need to tell Liquid its name and that it uses MathBlockTag
+  %w[theorem postulate corollary lemma axiom definition proof].each do |block_type|
+    Liquid::Template.register_tag(block_type, MathBlockTag)
+  end
+end

--- a/_plugins/math_block_tags.rb
+++ b/_plugins/math_block_tags.rb
@@ -1,42 +1,88 @@
-# filepath: /_plugins/math_block_tags.rb
 require 'cgi' # For HTML escaping
 
 module Jekyll
+  # Stores display names for block types, matching your SCSS.
+  BLOCK_TYPE_NAMES = {
+    'theorem'    => 'Teorema',
+    'postulate'  => 'Postulado',
+    'corollary'  => 'Corolario',
+    'lemma'      => 'Lema',
+    'axiom'      => 'Axioma',
+    'definition' => 'Definición',
+    'proof'      => 'Prueba' # Spanish for Proof
+  }.freeze
+
   class MathBlockTag < Liquid::Block
     def initialize(tag_name, markup, tokens)
       super
       @markup = markup.strip
       @block_type = tag_name # 'theorem', 'definition', etc.
 
-      # Regex to capture title and label, supporting various quote styles or no quotes for label
-      # title="Anything here", title='Anything here'
-      # label=my-label, label="my-label", label='my-label'
-      @title = @markup.match(/title=(?:"([^"]*)"|'([^']*)'|(\S+))/i)&.captures&.compact&.first
-      @label = @markup.match(/label=(?:"([^"]*)"|'([^']*)'|([a-zA-Z0-9_-]+))/i)&.captures&.compact&.first
+      # Regex to capture title (must be quoted) and label (can be unquoted)
+      @title_param = @markup.match(/title=(?:"([^"]*)"|'([^']*)')/i)&.captures&.compact&.first
+      @label_param = @markup.match(/label=(?:"([^"]*)"|'([^']*)'|([a-zA-Z0-9_-]+))/i)&.captures&.compact&.first
     end
 
     def render(context)
       site = context.registers[:site]
       converter = site.find_converter_instance(Jekyll::Converters::Markdown)
-      
-      # Render the content within the block using Liquid, then convert to HTML using Markdown
+
+      # Initialize counters and reference data store if they don't exist on the site object
+      site.config['math_block_counters'] ||= Hash.new(0)
+      site.config['math_block_references'] ||= {}
+
+      # Increment counter for this block type and get current number
+      current_number = (site.config['math_block_counters'][@block_type] += 1)
+      display_block_name = BLOCK_TYPE_NAMES[@block_type] || @block_type.capitalize
+
+      # Store reference data if a label is provided
+      if @label_param && !@label_param.strip.empty?
+        clean_label = @label_param.strip
+        site.config['math_block_references'][clean_label] = {
+          'type_key'    => @block_type, # e.g., 'theorem'
+          'name'        => display_block_name, # e.g., 'Teorema'
+          'number'      => current_number,
+          'title_param' => @title_param ? @title_param.strip : nil, # The user-provided title string
+          'id'          => clean_label # The label used for the HTML id
+        }
+      end
+
       raw_block_content = super(context) # Renders content between {% tag %} and {% endtag %}
       processed_content = converter.convert(raw_block_content.strip).strip
 
-      title_span_content = @title && !@title.strip.empty? ? CGI.escapeHTML(@title.strip) : ""
-      title_span = "<span class=\"math-block-title\">#{title_span_content}</span>"
+      # Construct the title string (e.g., "Teorema 1. Título Opcional")
+      block_title_str = ""
+      escaped_user_title = @title_param ? CGI.escapeHTML(@title_param.strip) : ""
+
+      if @block_type == "proof"
+        if !escaped_user_title.empty?
+          # If user provides a title for a proof, it's typically the subject.
+          # Your SCSS for .proof.has-subject .math-block-title::before had content: "";
+          # This implies the title attribute itself is the full intended title.
+          block_title_str = escaped_user_title # e.g., User writes title="Prueba del Teorema de Pitágoras"
+        else
+          block_title_str = "#{display_block_name}." # "Prueba."
+        end
+      else
+        block_title_str = "#{display_block_name} #{current_number}."
+        if !escaped_user_title.empty?
+          block_title_str += " #{escaped_user_title}"
+        end
+      end
+
+      title_span = "<span class=\"math-block-title\">#{block_title_str}</span>"
 
       id_attribute = ""
-      if @label && !@label.strip.empty?
-        id_attribute = " id=\"#{CGI.escapeHTML(@label.strip)}\""
+      if @label_param && !@label_param.strip.empty?
+        id_attribute = " id=\"#{CGI.escapeHTML(@label_param.strip)}\""
       end
       
       css_class = "math-block #{@block_type}"
-      if @block_type == "proof" && @title && !@title.strip.empty?
-        css_class += " has-subject"
+      # Add 'has-subject' if a proof has a specific title provided by the user
+      if @block_type == "proof" && @title_param && !@title_param.strip.empty?
+         css_class += " has-subject"
       end
 
-      # Construct the HTML output
       output = <<~HTML
         <div class="#{css_class}"#{id_attribute}>
           #{title_span}
@@ -49,9 +95,43 @@ module Jekyll
     end
   end
 
+  class MathRefTag < Liquid::Tag
+    def initialize(tag_name, markup, tokens)
+      super
+      @label_arg = markup.strip # This is the 'label-id' from {% math_ref label-id %}
+      if @label_arg.empty?
+        raise SyntaxError, "No label provided for math_ref tag. Usage: {% math_ref your-label %}"
+      end
+      unless @label_arg.match?(/^[a-zA-Z0-9_-]+$/)
+        raise SyntaxError, "Invalid characters in label for math_ref tag: '#{@label_arg}'. Use letters, numbers, hyphens, or underscores."
+      end
+    end
+
+    def render(context)
+      site = context.registers[:site]
+      references = site.config['math_block_references']
+
+      if references && references.key?(@label_arg)
+        ref_data = references[@label_arg]
+        
+        # Link text: "Teorema 1", "Definición 2", etc.
+        link_text = "#{ref_data['name']} #{ref_data['number']}"
+        href_id = CGI.escapeHTML(ref_data['id']) # id is the clean label
+
+        "<a href=\"##{href_id}\">#{CGI.escapeHTML(link_text)}</a>"
+      else
+        Jekyll.logger.warn "Math Reference Warning:", "Label '#{@label_arg}' not found for math_ref tag."
+        # Return a user-friendly message in Spanish
+        "[Referencia a '#{CGI.escapeHTML(@label_arg)}' no encontrada]"
+      end
+    end
+  end
+
   # Register each specific math block type
-  # For each type, we just need to tell Liquid its name and that it uses MathBlockTag
-  %w[theorem postulate corollary lemma axiom definition proof].each do |block_type|
+  BLOCK_TYPE_NAMES.keys.each do |block_type|
     Liquid::Template.register_tag(block_type, MathBlockTag)
   end
+
+  # Register the MathRefTag
+  Liquid::Template.register_tag('math_ref', MathRefTag)
 end

--- a/_posts/2025-05-05-identidades-trigonometricas-parte-1.md
+++ b/_posts/2025-05-05-identidades-trigonometricas-parte-1.md
@@ -11,6 +11,28 @@ featured: true
 toc: true
 ---
 
+<div class="math-block theorem">
+	<span class="math-block-title">Teorema de Pitagoras</span>
+	<div class="math-block-body">
+		Contenido aqui.
+	</div>
+</div>
+
+
+<div class="math-block postulate">
+	<span class="math-block-title">Postulado 1</span>
+	<div class="math-block-body">
+		Contenido aqui.
+	</div>
+</div>
+
+<div class="math-block definition">
+	<span class="math-block-title">Definición</span>
+	<div class="math-block-body">
+		Contenido aqui.
+	</div>
+</div>
+
 En la enseñanza tradicional, las identidades trigonométricas suelen presentarse a los estudiantes como fórmulas a memorizar, sin detenerse en el razonamiento geométrico o histórico que las sustenta. Sin embargo, estas relaciones no surgieron de manera arbitraria: las identidades pitagóricas, de ángulo doble y de ángulo medio tienen un origen común en la interpretación de la circunferencia unitaria y en las demostraciones clásicas basadas en triángulos inscritos. Explorar el génesis de cada identidad —desde la ecuación fundamental $$sin^2 \vartheta + \cos^2 \vartheta =1$$, hasta las fórmulas para $$\sin 2\vartheta$$ y $$\cos 2\vartheta$$, y la deducción de las fórmulas de ángulo medio— no solo clarifica su sentido, sino que convierte el aprendizaje en un proceso lógico de derivación. De este modo, como estudiantes, y también como docentes, podremos generar identidades nuevas a partir de unas pocas relaciones elementales, reduciendo la dependencia de la memorización y fomentando una comprensión más profunda y flexible de su origen y su aplicación.
 
 ## Círculo Unitario

--- a/_posts/2025-05-05-identidades-trigonometricas-parte-1.md
+++ b/_posts/2025-05-05-identidades-trigonometricas-parte-1.md
@@ -11,46 +11,6 @@ featured: true
 toc: true
 ---
 
-{% theorem title="Teorema de Pitágoras" label="th-pitagoras" %}
-$$a^2 + b^2 = c^2$$
-{% endtheorem %}
-
-{% postulate title="Mi postulado" label="ps-postulate" %}
-Contenido aca.
-{% endpostulate %}
-
-{% definition label="df-def1" %}
-Contenido aca.
-{% enddefinition %}
-
-{% proof label="proof-1" %}
-Demostracion
-{% endproof %}
-
-Podemos ver que {% math_ref th-pitagoras %} nos permite...
-
-<!-- <div class="math-block theorem">
-	<span class="math-block-title">Teorema de Pitagoras</span>
-	<div class="math-block-body">
-		Contenido aqui.
-	</div>
-</div>
-
-
-<div class="math-block postulate">
-	<span class="math-block-title">Postulado 1</span>
-	<div class="math-block-body">
-		Contenido aqui.
-	</div>
-</div>
-
-<div class="math-block definition">
-	<span class="math-block-title">Definición</span>
-	<div class="math-block-body">
-		Contenido aqui.
-	</div>
-</div> -->
-
 En la enseñanza tradicional, las identidades trigonométricas suelen presentarse a los estudiantes como fórmulas a memorizar, sin detenerse en el razonamiento geométrico o histórico que las sustenta. Sin embargo, estas relaciones no surgieron de manera arbitraria: las identidades pitagóricas, de ángulo doble y de ángulo medio tienen un origen común en la interpretación de la circunferencia unitaria y en las demostraciones clásicas basadas en triángulos inscritos. Explorar el génesis de cada identidad —desde la ecuación fundamental $$sin^2 \vartheta + \cos^2 \vartheta =1$$, hasta las fórmulas para $$\sin 2\vartheta$$ y $$\cos 2\vartheta$$, y la deducción de las fórmulas de ángulo medio— no solo clarifica su sentido, sino que convierte el aprendizaje en un proceso lógico de derivación. De este modo, como estudiantes, y también como docentes, podremos generar identidades nuevas a partir de unas pocas relaciones elementales, reduciendo la dependencia de la memorización y fomentando una comprensión más profunda y flexible de su origen y su aplicación.
 
 ## Círculo Unitario

--- a/_posts/2025-05-05-identidades-trigonometricas-parte-1.md
+++ b/_posts/2025-05-05-identidades-trigonometricas-parte-1.md
@@ -11,7 +11,25 @@ featured: true
 toc: true
 ---
 
-<div class="math-block theorem">
+{% theorem title="Teorema de Pitágoras" label="th-pitagoras" %}
+$$a^2 + b^2 = c^2$$
+{% endtheorem %}
+
+{% postulate title="Mi postulado" label="ps-postulate" %}
+Contenido aca.
+{% endpostulate %}
+
+{% definition label="df-def1" %}
+Contenido aca.
+{% enddefinition %}
+
+{% proof label="proof-1" %}
+Demostracion
+{% endproof %}
+
+Podemos ver que {% math_ref th-pitagoras %} nos permite...
+
+<!-- <div class="math-block theorem">
 	<span class="math-block-title">Teorema de Pitagoras</span>
 	<div class="math-block-body">
 		Contenido aqui.
@@ -31,7 +49,7 @@ toc: true
 	<div class="math-block-body">
 		Contenido aqui.
 	</div>
-</div>
+</div> -->
 
 En la enseñanza tradicional, las identidades trigonométricas suelen presentarse a los estudiantes como fórmulas a memorizar, sin detenerse en el razonamiento geométrico o histórico que las sustenta. Sin embargo, estas relaciones no surgieron de manera arbitraria: las identidades pitagóricas, de ángulo doble y de ángulo medio tienen un origen común en la interpretación de la circunferencia unitaria y en las demostraciones clásicas basadas en triángulos inscritos. Explorar el génesis de cada identidad —desde la ecuación fundamental $$sin^2 \vartheta + \cos^2 \vartheta =1$$, hasta las fórmulas para $$\sin 2\vartheta$$ y $$\cos 2\vartheta$$, y la deducción de las fórmulas de ángulo medio— no solo clarifica su sentido, sino que convierte el aprendizaje en un proceso lógico de derivación. De este modo, como estudiantes, y también como docentes, podremos generar identidades nuevas a partir de unas pocas relaciones elementales, reduciendo la dependencia de la memorización y fomentando una comprensión más profunda y flexible de su origen y su aplicación.
 

--- a/_sass/5-theorems/theorems.scss
+++ b/_sass/5-theorems/theorems.scss
@@ -15,7 +15,7 @@
     // Store original color palette for reference or direct use
     --original-theorem-bg: #e6f7ff;
     --original-theorem-border: #91d5ff;
-    --original-theorem-text: #0050b3;
+    --original-theorem-text: #0050b3;    
 
     --original-postulate-bg: #fffbe6;
     --original-postulate-border: #ffe58f;
@@ -37,10 +37,11 @@
     --original-definition-border: #87e8de;
     --original-definition-text: #006d75;
 
-    --original-proof-bg: #f9f0ff;
-    --original-proof-border: #d3adf7;
-    --original-proof-text: #531dab;
-    --original-proof-qed-color: #531dab; // Keep for QED symbol
+    --original-proof-bg: #e8f5e9;         // Very Light Yellow
+    --original-proof-border: #81c784;     // Medium Amber
+    --original-proof-text: #2e7d32;       // Dark Amber/Orange
+    --original-proof-qed-color: #2e7d32;  // QED to match new proof text color
+
 
     // New color variable structure
     // Title text color will be the same as the body background color.
@@ -101,7 +102,7 @@
 .math-block {
     margin: var(--math-block-margin);
     border-radius: var(--math-block-border-radius);
-    border-style: solid; /* This is the outer border */
+    // border-style: solid; /* This is the outer border */
     border-width: var(--math-block-border-width); /* This is the outer border */
     font-family: var(--math-block-font-family);
     position: relative;

--- a/_sass/5-theorems/theorems.scss
+++ b/_sass/5-theorems/theorems.scss
@@ -1,0 +1,161 @@
+:root {
+    --theorem-bg: #e6f7ff;
+    --theorem-border: #91d5ff;
+    --theorem-text: #0050b3;
+
+    --postulate-bg: #fffbe6;
+    --postulate-border: #ffe58f;
+    --postulate-text: #ad8b00;
+
+    --corollary-bg: #f6ffed;
+    --corollary-border: #b7eb8f;
+    --corollary-text: #389e0d;
+
+    --lemma-bg: #fff0f6;
+    --lemma-border: #ffadd2;
+    --lemma-text: #c41d7f;
+
+    --axiom-bg: #f0f5ff;
+    --axiom-border: #adc6ff;
+    --axiom-text: #1d39c4;
+
+    --definition-bg: #e6fffb;
+    --definition-border: #87e8de;
+    --definition-text: #006d75;
+
+    --proof-bg: #f9f0ff;
+    --proof-border: #d3adf7;
+    --proof-text: #531dab;
+    --proof-qed-color: #531dab;
+
+    --math-block-padding: 15px;
+    --math-block-margin: 20px 0;
+    --math-block-border-radius: 8px;
+    --math-block-border-width: 2px;
+    --math-block-font-family: 'Georgia', serif; /* Or any preferred serif font */
+}
+
+body {
+    counter-reset: theorem-counter postulate-counter corollary-counter lemma-counter axiom-counter definition-counter;
+}
+
+.math-block {
+    padding: var(--math-block-padding);
+    margin: var(--math-block-margin);
+    border-radius: var(--math-block-border-radius);
+    border-style: solid;
+    border-width: var(--math-block-border-width);
+    font-family: var(--math-block-font-family);
+    position: relative; /* For QED symbol positioning in proofs */
+}
+
+.math-block-title {
+    font-weight: bold;
+    margin-bottom: 10px;
+    display: block;
+}
+
+.math-block-body {
+    line-height: 1.6;
+}
+
+/* Theorem */
+.theorem {
+    background-color: var(--theorem-bg);
+    border-color: var(--theorem-border);
+    color: var(--theorem-text);
+}
+.theorem .math-block-title::before {
+    content: "Theorem " counter(theorem-counter) ". ";
+    counter-increment: theorem-counter;
+    font-weight: bold;
+}
+
+/* Postulate */
+.postulate {
+    background-color: var(--postulate-bg);
+    border-color: var(--postulate-border);
+    color: var(--postulate-text);
+}
+.postulate .math-block-title::before {
+    content: "Postulate " counter(postulate-counter) ". ";
+    counter-increment: postulate-counter;
+    font-weight: bold;
+}
+
+/* Corollary */
+.corollary {
+    background-color: var(--corollary-bg);
+    border-color: var(--corollary-border);
+    color: var(--corollary-text);
+}
+.corollary .math-block-title::before {
+    content: "Corollary " counter(corollary-counter) ". ";
+    counter-increment: corollary-counter;
+    font-weight: bold;
+}
+
+/* Lemma */
+.lemma {
+    background-color: var(--lemma-bg);
+    border-color: var(--lemma-border);
+    color: var(--lemma-text);
+}
+.lemma .math-block-title::before {
+    content: "Lemma " counter(lemma-counter) ". ";
+    counter-increment: lemma-counter;
+    font-weight: bold;
+}
+
+/* Axiom */
+.axiom {
+    background-color: var(--axiom-bg);
+    border-color: var(--axiom-border);
+    color: var(--axiom-text);
+}
+.axiom .math-block-title::before {
+    content: "Axiom " counter(axiom-counter) ". ";
+    counter-increment: axiom-counter;
+    font-weight: bold;
+}
+
+/* Definition */
+.definition {
+    background-color: var(--definition-bg);
+    border-color: var(--definition-border);
+    color: var(--definition-text);
+}
+.definition .math-block-title::before {
+    content: "Definition " counter(definition-counter) ". ";
+    counter-increment: definition-counter;
+    font-weight: bold;
+}
+
+/* Proof */
+.proof {
+    background-color: var(--proof-bg);
+    border-color: var(--proof-border);
+    color: var(--proof-text);
+    padding-bottom: 30px; /* Space for QED symbol */
+}
+.proof .math-block-title { /* Proofs usually don't have numbers or explicit titles like "Proof X" */
+    font-style: italic;
+}
+.proof .math-block-title::before {
+    content: "Proof. "; /* Or just "Proof: " */
+    font-weight: bold;
+    font-style: italic;
+}
+.proof .math-block-body::after {
+    content: "□"; /* QED symbol */
+    font-weight: bold;
+    color: var(--proof-qed-color);
+    position: absolute;
+    right: var(--math-block-padding);
+    bottom: calc(var(--math-block-padding) - 5px); /* Adjust as needed */
+    font-size: 1.2em;
+}
+/* If a proof has a specific subject, e.g. "Proof of Theorem 1" */
+.proof.has-subject .math-block-title::before {
+    content: ""; /* Remove default "Proof. " */
+}

--- a/_sass/5-theorems/theorems.scss
+++ b/_sass/5-theorems/theorems.scss
@@ -1,161 +1,234 @@
 :root {
-    --theorem-bg: #e6f7ff;
-    --theorem-border: #91d5ff;
-    --theorem-text: #0050b3;
-
-    --postulate-bg: #fffbe6;
-    --postulate-border: #ffe58f;
-    --postulate-text: #ad8b00;
-
-    --corollary-bg: #f6ffed;
-    --corollary-border: #b7eb8f;
-    --corollary-text: #389e0d;
-
-    --lemma-bg: #fff0f6;
-    --lemma-border: #ffadd2;
-    --lemma-text: #c41d7f;
-
-    --axiom-bg: #f0f5ff;
-    --axiom-border: #adc6ff;
-    --axiom-text: #1d39c4;
-
-    --definition-bg: #e6fffb;
-    --definition-border: #87e8de;
-    --definition-text: #006d75;
-
-    --proof-bg: #f9f0ff;
-    --proof-border: #d3adf7;
-    --proof-text: #531dab;
-    --proof-qed-color: #531dab;
-
-    --math-block-padding: 15px;
+    // General layout vars (from your existing setup)
     --math-block-margin: 20px 0;
     --math-block-border-radius: 8px;
     --math-block-border-width: 2px;
-    --math-block-font-family: 'Georgia', serif; /* Or any preferred serif font */
+    --math-block-font-family: 'Georgia', serif;
+
+    // Padding for the new title and body structure
+    --math-title-padding: 8px 12px;
+    --math-body-padding: 12px;
+
+    // Store original color palette for reference or direct use
+    --original-theorem-bg: #e6f7ff;
+    --original-theorem-border: #91d5ff;
+    --original-theorem-text: #0050b3;
+
+    --original-postulate-bg: #fffbe6;
+    --original-postulate-border: #ffe58f;
+    --original-postulate-text: #ad8b00;
+
+    --original-corollary-bg: #f6ffed;
+    --original-corollary-border: #b7eb8f;
+    --original-corollary-text: #389e0d;
+
+    --original-lemma-bg: #fff0f6;
+    --original-lemma-border: #ffadd2;
+    --original-lemma-text: #c41d7f;
+
+    --original-axiom-bg: #f0f5ff;
+    --original-axiom-border: #adc6ff;
+    --original-axiom-text: #1d39c4;
+
+    --original-definition-bg: #e6fffb;
+    --original-definition-border: #87e8de;
+    --original-definition-text: #006d75;
+
+    --original-proof-bg: #f9f0ff;
+    --original-proof-border: #d3adf7;
+    --original-proof-text: #531dab;
+    --original-proof-qed-color: #531dab; // Keep for QED symbol
+
+    // New color variable structure
+    // Title text color will be the same as the body background color,
+    // and body text color will be the same as the title background color.
+    // This creates a two-tone effect per block type.
+
+    // Theorem
+    --theorem-title-bg: var(--original-theorem-text);
+    --theorem-title-text: var(--original-theorem-bg);
+    --theorem-body-bg: var(--original-theorem-bg);
+    --theorem-body-text: var(--original-theorem-text);
+    --theorem-outer-border: var(--original-theorem-border);
+
+    // Postulate
+    --postulate-title-bg: var(--original-postulate-text);
+    --postulate-title-text: var(--original-postulate-bg);
+    --postulate-body-bg: var(--original-postulate-bg);
+    --postulate-body-text: var(--original-postulate-text);
+    --postulate-outer-border: var(--original-postulate-border);
+
+    // Corollary
+    --corollary-title-bg: var(--original-corollary-text);
+    --corollary-title-text: var(--original-corollary-bg);
+    --corollary-body-bg: var(--original-corollary-bg);
+    --corollary-body-text: var(--original-corollary-text);
+    --corollary-outer-border: var(--original-corollary-border);
+
+    // Lemma
+    --lemma-title-bg: var(--original-lemma-text);
+    --lemma-title-text: var(--original-lemma-bg);
+    --lemma-body-bg: var(--original-lemma-bg);
+    --lemma-body-text: var(--original-lemma-text);
+    --lemma-outer-border: var(--original-lemma-border);
+
+    // Axiom
+    --axiom-title-bg: var(--original-axiom-text);
+    --axiom-title-text: var(--original-axiom-bg);
+    --axiom-body-bg: var(--original-axiom-bg);
+    --axiom-body-text: var(--original-axiom-text);
+    --axiom-outer-border: var(--original-axiom-border);
+
+    // Definition
+    --definition-title-bg: var(--original-definition-text);
+    --definition-title-text: var(--original-definition-bg);
+    --definition-body-bg: var(--original-definition-bg);
+    --definition-body-text: var(--original-definition-text);
+    --definition-outer-border: var(--original-definition-border);
+
+    // Proof
+    --proof-title-bg: var(--original-proof-text);
+    --proof-title-text: var(--original-proof-bg);
+    --proof-body-bg: var(--original-proof-bg);
+    --proof-body-text: var(--original-proof-text);
+    --proof-outer-border: var(--original-proof-border);
+    --proof-qed-color: var(--original-proof-qed-color); // QED color remains distinct
 }
 
-body {
-    counter-reset: theorem-counter postulate-counter corollary-counter lemma-counter axiom-counter definition-counter;
-}
-
+/* General Math Block Styling */
 .math-block {
-    padding: var(--math-block-padding);
     margin: var(--math-block-margin);
     border-radius: var(--math-block-border-radius);
     border-style: solid;
     border-width: var(--math-block-border-width);
     font-family: var(--math-block-font-family);
     position: relative; /* For QED symbol positioning in proofs */
+    overflow: hidden; /* Ensures border-radius clips children backgrounds correctly */
+    // Note: No padding here, as title and body will have their own.
 }
 
 .math-block-title {
+    padding: var(--math-title-padding);
     font-weight: bold;
-    margin-bottom: 10px;
     display: block;
+    // border-bottom: 1px solid; /* Optional: if you want a line between title and body */
+    // border-bottom-color: inherit; /* Will inherit border-color from .math-block */
+}
+
+.proof .math-block-title { /* Keep proof title italic if desired */
+    font-style: italic;
 }
 
 .math-block-body {
+    padding: var(--math-body-padding);
     line-height: 1.6;
 }
 
-/* Theorem */
-.theorem {
-    background-color: var(--theorem-bg);
-    border-color: var(--theorem-border);
-    color: var(--theorem-text);
-}
-.theorem .math-block-title::before {
-    content: "Teorema " counter(theorem-counter) ". ";
-    counter-increment: theorem-counter;
-    font-weight: bold;
-}
-
-/* Postulate */
-.postulate {
-    background-color: var(--postulate-bg);
-    border-color: var(--postulate-border);
-    color: var(--postulate-text);
-}
-.postulate .math-block-title::before {
-    content: "Postulado " counter(postulate-counter) ". ";
-    counter-increment: postulate-counter;
-    font-weight: bold;
-}
-
-/* Corollary */
-.corollary {
-    background-color: var(--corollary-bg);
-    border-color: var(--corollary-border);
-    color: var(--corollary-text);
-}
-.corollary .math-block-title::before {
-    content: "Corolario " counter(corollary-counter) ". ";
-    counter-increment: corollary-counter;
-    font-weight: bold;
-}
-
-/* Lemma */
-.lemma {
-    background-color: var(--lemma-bg);
-    border-color: var(--lemma-border);
-    color: var(--lemma-text);
-}
-.lemma .math-block-title::before {
-    content: "Lema " counter(lemma-counter) ". ";
-    counter-increment: lemma-counter;
-    font-weight: bold;
-}
-
-/* Axiom */
-.axiom {
-    background-color: var(--axiom-bg);
-    border-color: var(--axiom-border);
-    color: var(--axiom-text);
-}
-.axiom .math-block-title::before {
-    content: "Axioma " counter(axiom-counter) ". ";
-    counter-increment: axiom-counter;
-    font-weight: bold;
-}
-
-/* Definition */
-.definition {
-    background-color: var(--definition-bg);
-    border-color: var(--definition-border);
-    color: var(--definition-text);
-}
-.definition .math-block-title::before {
-    content: "Definición " counter(definition-counter) ". ";
-    counter-increment: definition-counter;
-    font-weight: bold;
-}
-
-/* Proof */
-.proof {
-    background-color: var(--proof-bg);
-    border-color: var(--proof-border);
-    color: var(--proof-text);
-    padding-bottom: 30px; /* Space for QED symbol */
-}
-.proof .math-block-title { /* Proofs usually don't have numbers or explicit titles like "Proof X" */
-    font-style: italic;
-}
-.proof .math-block-title::before {
-    content: "Proof. "; /* Or just "Proof: " */
-    font-weight: bold;
-    font-style: italic;
-}
+/* QED symbol for proofs */
 .proof .math-block-body::after {
     content: "□"; /* QED symbol */
     font-weight: bold;
-    color: var(--proof-qed-color);
+    color: var(--proof-qed-color); /* Uses specific QED color var */
     position: absolute;
-    right: var(--math-block-padding);
-    bottom: calc(var(--math-block-padding) - 5px); /* Adjust as needed */
+    right: var(--math-body-padding);
+    bottom: var(--math-body-padding);
     font-size: 1.2em;
 }
-/* If a proof has a specific subject, e.g. "Proof of Theorem 1" */
-.proof.has-subject .math-block-title::before {
-    content: ""; /* Remove default "Proof. " */
+
+/* Adjust proof body padding to make space for QED symbol */
+.proof .math-block-body {
+    padding-bottom: calc(var(--math-body-padding) + 1.5em); /* Extra space for QED */
+}
+
+/* Apply specific colors per type */
+.theorem {
+    border-color: var(--theorem-outer-border);
+    .math-block-title {
+        background-color: var(--theorem-title-bg);
+        color: var(--theorem-title-text);
+        // border-bottom-color: var(--theorem-outer-border); /* If using border-bottom on title */
+    }
+    .math-block-body {
+        background-color: var(--theorem-body-bg);
+        color: var(--theorem-body-text);
+    }
+}
+
+.postulate {
+    border-color: var(--postulate-outer-border);
+    .math-block-title {
+        background-color: var(--postulate-title-bg);
+        color: var(--postulate-title-text);
+        // border-bottom-color: var(--postulate-outer-border);
+    }
+    .math-block-body {
+        background-color: var(--postulate-body-bg);
+        color: var(--postulate-body-text);
+    }
+}
+
+.corollary {
+    border-color: var(--corollary-outer-border);
+    .math-block-title {
+        background-color: var(--corollary-title-bg);
+        color: var(--corollary-title-text);
+        // border-bottom-color: var(--corollary-outer-border);
+    }
+    .math-block-body {
+        background-color: var(--corollary-body-bg);
+        color: var(--corollary-body-text);
+    }
+}
+
+.lemma {
+    border-color: var(--lemma-outer-border);
+    .math-block-title {
+        background-color: var(--lemma-title-bg);
+        color: var(--lemma-title-text);
+        // border-bottom-color: var(--lemma-outer-border);
+    }
+    .math-block-body {
+        background-color: var(--lemma-body-bg);
+        color: var(--lemma-body-text);
+    }
+}
+
+.axiom {
+    border-color: var(--axiom-outer-border);
+    .math-block-title {
+        background-color: var(--axiom-title-bg);
+        color: var(--axiom-title-text);
+        // border-bottom-color: var(--axiom-outer-border);
+    }
+    .math-block-body {
+        background-color: var(--axiom-body-bg);
+        color: var(--axiom-body-text);
+    }
+}
+
+.definition {
+    border-color: var(--definition-outer-border);
+    .math-block-title {
+        background-color: var(--definition-title-bg);
+        color: var(--definition-title-text);
+        // border-bottom-color: var(--definition-outer-border);
+    }
+    .math-block-body {
+        background-color: var(--definition-body-bg);
+        color: var(--definition-body-text);
+    }
+}
+
+.proof {
+    border-color: var(--proof-outer-border);
+    .math-block-title {
+        background-color: var(--proof-title-bg);
+        color: var(--proof-title-text);
+        // border-bottom-color: var(--proof-outer-border);
+    }
+    .math-block-body {
+        background-color: var(--proof-body-bg);
+        color: var(--proof-body-text);
+        /* padding-bottom is already adjusted above for QED */
+    }
 }

--- a/_sass/5-theorems/theorems.scss
+++ b/_sass/5-theorems/theorems.scss
@@ -66,7 +66,7 @@ body {
     color: var(--theorem-text);
 }
 .theorem .math-block-title::before {
-    content: "Theorem " counter(theorem-counter) ". ";
+    content: "Teorema " counter(theorem-counter) ". ";
     counter-increment: theorem-counter;
     font-weight: bold;
 }
@@ -78,7 +78,7 @@ body {
     color: var(--postulate-text);
 }
 .postulate .math-block-title::before {
-    content: "Postulate " counter(postulate-counter) ". ";
+    content: "Postulado " counter(postulate-counter) ". ";
     counter-increment: postulate-counter;
     font-weight: bold;
 }
@@ -90,7 +90,7 @@ body {
     color: var(--corollary-text);
 }
 .corollary .math-block-title::before {
-    content: "Corollary " counter(corollary-counter) ". ";
+    content: "Corolario " counter(corollary-counter) ". ";
     counter-increment: corollary-counter;
     font-weight: bold;
 }
@@ -102,7 +102,7 @@ body {
     color: var(--lemma-text);
 }
 .lemma .math-block-title::before {
-    content: "Lemma " counter(lemma-counter) ". ";
+    content: "Lema " counter(lemma-counter) ". ";
     counter-increment: lemma-counter;
     font-weight: bold;
 }
@@ -114,7 +114,7 @@ body {
     color: var(--axiom-text);
 }
 .axiom .math-block-title::before {
-    content: "Axiom " counter(axiom-counter) ". ";
+    content: "Axioma " counter(axiom-counter) ". ";
     counter-increment: axiom-counter;
     font-weight: bold;
 }
@@ -126,7 +126,7 @@ body {
     color: var(--definition-text);
 }
 .definition .math-block-title::before {
-    content: "Definition " counter(definition-counter) ". ";
+    content: "Definición " counter(definition-counter) ". ";
     counter-increment: definition-counter;
     font-weight: bold;
 }

--- a/_sass/5-theorems/theorems.scss
+++ b/_sass/5-theorems/theorems.scss
@@ -9,6 +9,9 @@
     --math-title-padding: 8px 12px;
     --math-body-padding: 12px;
 
+    // Define a standard black color for body text
+    --math-body-text-color-default: #000000; // Or a dark gray like #333333 if preferred
+
     // Store original color palette for reference or direct use
     --original-theorem-bg: #e6f7ff;
     --original-theorem-border: #91d5ff;
@@ -40,95 +43,93 @@
     --original-proof-qed-color: #531dab; // Keep for QED symbol
 
     // New color variable structure
-    // Title text color will be the same as the body background color,
-    // and body text color will be the same as the title background color.
-    // This creates a two-tone effect per block type.
+    // Title text color will be the same as the body background color.
+    // Body text color is now always black (or a dark default).
 
     // Theorem
     --theorem-title-bg: var(--original-theorem-text);
     --theorem-title-text: var(--original-theorem-bg);
     --theorem-body-bg: var(--original-theorem-bg);
-    --theorem-body-text: var(--original-theorem-text);
+    // --theorem-body-text: var(--original-theorem-text); // No longer used for body text color
     --theorem-outer-border: var(--original-theorem-border);
 
     // Postulate
     --postulate-title-bg: var(--original-postulate-text);
     --postulate-title-text: var(--original-postulate-bg);
     --postulate-body-bg: var(--original-postulate-bg);
-    --postulate-body-text: var(--original-postulate-text);
+    // --postulate-body-text: var(--original-postulate-text); // No longer used
     --postulate-outer-border: var(--original-postulate-border);
 
     // Corollary
     --corollary-title-bg: var(--original-corollary-text);
     --corollary-title-text: var(--original-corollary-bg);
     --corollary-body-bg: var(--original-corollary-bg);
-    --corollary-body-text: var(--original-corollary-text);
+    // --corollary-body-text: var(--original-corollary-text); // No longer used
     --corollary-outer-border: var(--original-corollary-border);
 
     // Lemma
     --lemma-title-bg: var(--original-lemma-text);
     --lemma-title-text: var(--original-lemma-bg);
     --lemma-body-bg: var(--original-lemma-bg);
-    --lemma-body-text: var(--original-lemma-text);
+    // --lemma-body-text: var(--original-lemma-text); // No longer used
     --lemma-outer-border: var(--original-lemma-border);
 
     // Axiom
     --axiom-title-bg: var(--original-axiom-text);
     --axiom-title-text: var(--original-axiom-bg);
     --axiom-body-bg: var(--original-axiom-bg);
-    --axiom-body-text: var(--original-axiom-text);
+    // --axiom-body-text: var(--original-axiom-text); // No longer used
     --axiom-outer-border: var(--original-axiom-border);
 
     // Definition
     --definition-title-bg: var(--original-definition-text);
     --definition-title-text: var(--original-definition-bg);
     --definition-body-bg: var(--original-definition-bg);
-    --definition-body-text: var(--original-definition-text);
+    // --definition-body-text: var(--original-definition-text); // No longer used
     --definition-outer-border: var(--original-definition-border);
 
     // Proof
     --proof-title-bg: var(--original-proof-text);
     --proof-title-text: var(--original-proof-bg);
     --proof-body-bg: var(--original-proof-bg);
-    --proof-body-text: var(--original-proof-text);
+    // --proof-body-text: var(--original-proof-text); // No longer used
     --proof-outer-border: var(--original-proof-border);
-    --proof-qed-color: var(--original-proof-qed-color); // QED color remains distinct
+    --proof-qed-color: var(--original-proof-qed-color);
 }
 
 /* General Math Block Styling */
 .math-block {
     margin: var(--math-block-margin);
     border-radius: var(--math-block-border-radius);
-    border-style: solid;
-    border-width: var(--math-block-border-width);
+    border-style: solid; /* This is the outer border */
+    border-width: var(--math-block-border-width); /* This is the outer border */
     font-family: var(--math-block-font-family);
-    position: relative; /* For QED symbol positioning in proofs */
-    overflow: hidden; /* Ensures border-radius clips children backgrounds correctly */
-    // Note: No padding here, as title and body will have their own.
+    position: relative;
+    overflow: hidden;
 }
 
 .math-block-title {
     padding: var(--math-title-padding);
     font-weight: bold;
     display: block;
-    // border-bottom: 1px solid; /* Optional: if you want a line between title and body */
-    // border-bottom-color: inherit; /* Will inherit border-color from .math-block */
 }
 
-.proof .math-block-title { /* Keep proof title italic if desired */
+.proof .math-block-title {
     font-style: italic;
 }
 
 .math-block-body {
     padding: var(--math-body-padding);
     line-height: 1.6;
+    color: var(--math-body-text-color-default); /* Body text is now always this color */
+    /* The .math-block-body itself does not have a border */
 }
 
 /* QED symbol for proofs */
 .proof .math-block-body::after {
-    content: "□"; /* QED symbol */
+    content: "□";
     font-weight: bold;
-    color: var(--proof-qed-color); /* Uses specific QED color var */
+    color: var(--proof-qed-color);
     position: absolute;
     right: var(--math-body-padding);
     bottom: var(--math-body-padding);
@@ -137,20 +138,23 @@
 
 /* Adjust proof body padding to make space for QED symbol */
 .proof .math-block-body {
-    padding-bottom: calc(var(--math-body-padding) + 1.5em); /* Extra space for QED */
+    padding-bottom: calc(var(--math-body-padding) + 1.5em);
 }
 
 /* Apply specific colors per type */
+/* The outer border is set on .math-block directly. */
+/* Title and Body backgrounds and Title text color are set here. */
+/* Body text color is now globally set to --math-body-text-color-default. */
+
 .theorem {
     border-color: var(--theorem-outer-border);
     .math-block-title {
         background-color: var(--theorem-title-bg);
         color: var(--theorem-title-text);
-        // border-bottom-color: var(--theorem-outer-border); /* If using border-bottom on title */
     }
     .math-block-body {
         background-color: var(--theorem-body-bg);
-        color: var(--theorem-body-text);
+        /* color: var(--theorem-body-text); // This line is removed */
     }
 }
 
@@ -159,11 +163,9 @@
     .math-block-title {
         background-color: var(--postulate-title-bg);
         color: var(--postulate-title-text);
-        // border-bottom-color: var(--postulate-outer-border);
     }
     .math-block-body {
         background-color: var(--postulate-body-bg);
-        color: var(--postulate-body-text);
     }
 }
 
@@ -172,11 +174,9 @@
     .math-block-title {
         background-color: var(--corollary-title-bg);
         color: var(--corollary-title-text);
-        // border-bottom-color: var(--corollary-outer-border);
     }
     .math-block-body {
         background-color: var(--corollary-body-bg);
-        color: var(--corollary-body-text);
     }
 }
 
@@ -185,11 +185,9 @@
     .math-block-title {
         background-color: var(--lemma-title-bg);
         color: var(--lemma-title-text);
-        // border-bottom-color: var(--lemma-outer-border);
     }
     .math-block-body {
         background-color: var(--lemma-body-bg);
-        color: var(--lemma-body-text);
     }
 }
 
@@ -198,11 +196,9 @@
     .math-block-title {
         background-color: var(--axiom-title-bg);
         color: var(--axiom-title-text);
-        // border-bottom-color: var(--axiom-outer-border);
     }
     .math-block-body {
         background-color: var(--axiom-body-bg);
-        color: var(--axiom-body-text);
     }
 }
 
@@ -211,11 +207,9 @@
     .math-block-title {
         background-color: var(--definition-title-bg);
         color: var(--definition-title-text);
-        // border-bottom-color: var(--definition-outer-border);
     }
     .math-block-body {
         background-color: var(--definition-body-bg);
-        color: var(--definition-body-text);
     }
 }
 
@@ -224,11 +218,9 @@
     .math-block-title {
         background-color: var(--proof-title-bg);
         color: var(--proof-title-text);
-        // border-bottom-color: var(--proof-outer-border);
     }
     .math-block-body {
         background-color: var(--proof-body-bg);
-        color: var(--proof-body-text);
-        /* padding-bottom is already adjusted above for QED */
+        /* QED symbol color is handled by --proof-qed-color */
     }
 }

--- a/_sass/5-theorems/theorems.scss
+++ b/_sass/5-theorems/theorems.scss
@@ -9,13 +9,13 @@
     --math-title-padding: 8px 12px;
     --math-body-padding: 12px;
 
-    // Define a standard black color for body text
-    --math-body-text-color-default: #000000; // Or a dark gray like #333333 if preferred
+    // Define a standard black color for body text (Light theme default)
+    --math-body-text-color-default: #000000;
 
-    // Store original color palette for reference or direct use
+    // Store original color palette for LIGHT THEME
     --original-theorem-bg: #e6f7ff;
     --original-theorem-border: #91d5ff;
-    --original-theorem-text: #0050b3;    
+    --original-theorem-text: #0050b3;
 
     --original-postulate-bg: #fffbe6;
     --original-postulate-border: #ffe58f;
@@ -37,76 +37,154 @@
     --original-definition-border: #87e8de;
     --original-definition-text: #006d75;
 
-    --original-proof-bg: #e8f5e9;         // Very Light Yellow
-    --original-proof-border: #81c784;     // Medium Amber
-    --original-proof-text: #2e7d32;       // Dark Amber/Orange
-    --original-proof-qed-color: #2e7d32;  // QED to match new proof text color
+    --original-proof-bg: #e8f5e9;
+    --original-proof-border: #81c784;
+    --original-proof-text: #2e7d32;
+    --original-proof-qed-color: #2e7d32;
+
+    // Store original color palette for DARK THEME (Desaturated Pastels)
+    --math-body-text-color-default-dark: #cccccc; // Light gray for dark mode body text
+
+    // Theorem - Blueish
+    --original-theorem-bg-dark: #3E5263;     // Dark Slate Blue (used for body bg & title text in dark mode)
+    --original-theorem-text-dark: #A8B8C5;   // Light Grayish Blue (used for title bg in dark mode)
+    --original-theorem-border-dark: #587083; // Medium Slate Blue (for borders)
+
+    // Postulate - Yellowish/Brownish
+    --original-postulate-bg-dark: #5A523E;   // Dark Khaki/Olive
+    --original-postulate-text-dark: #C2BBA7; // Light Khaki/Beige
+    --original-postulate-border-dark: #786F57;// Medium Khaki/Olive
+
+    // Corollary - Greenish
+    --original-corollary-bg-dark: #3E5A4C;   // Dark Desaturated Green
+    --original-corollary-text-dark: #A7C2B3; // Light Desaturated Green
+    --original-corollary-border-dark: #577867;// Medium Desaturated Green
+
+    // Lemma - Pinkish/Mauve
+    --original-lemma-bg-dark: #634A5F;       // Dark Mauve
+    --original-lemma-text-dark: #C5AEC0;     // Light Mauve
+    --original-lemma-border-dark: #83687E;   // Medium Mauve
+
+    // Axiom - Purplish-Blue
+    --original-axiom-bg-dark: #4A4A6A;       // Dark Slate Purple
+    --original-axiom-text-dark: #AEAFC9;     // Light Slate Purple
+    --original-axiom-border-dark: #68688B;   // Medium Slate Purple
+
+    // Definition - Teal/Cyanish
+    --original-definition-bg-dark: #3E5A5A;  // Dark Teal
+    --original-definition-text-dark: #A7C2C2;// Light Teal
+    --original-definition-border-dark: #577878; // Medium Teal
+
+    // Proof - Greenish-Gray/Neutral
+    --original-proof-bg-dark: #4F5A4E;       // Dark Desaturated Olive/Gray
+    --original-proof-text-dark: #B8C2B7;     // Light Desaturated Olive/Gray
+    --original-proof-border-dark: #6A7869;   // Medium Desaturated Olive/Gray
+    --original-proof-qed-color-dark: var(--original-proof-text-dark); // QED symbol matches text-dark color
 
 
-    // New color variable structure
-    // Title text color will be the same as the body background color.
-    // Body text color is now always black (or a dark default).
-
+    // New color variable structure (Defaults to LIGHT THEME)
+    // Light Theme: Title BG uses 'text' color, Title Text uses 'bg' color.
     // Theorem
     --theorem-title-bg: var(--original-theorem-text);
     --theorem-title-text: var(--original-theorem-bg);
     --theorem-body-bg: var(--original-theorem-bg);
-    // --theorem-body-text: var(--original-theorem-text); // No longer used for body text color
     --theorem-outer-border: var(--original-theorem-border);
 
     // Postulate
     --postulate-title-bg: var(--original-postulate-text);
     --postulate-title-text: var(--original-postulate-bg);
     --postulate-body-bg: var(--original-postulate-bg);
-    // --postulate-body-text: var(--original-postulate-text); // No longer used
     --postulate-outer-border: var(--original-postulate-border);
 
     // Corollary
     --corollary-title-bg: var(--original-corollary-text);
     --corollary-title-text: var(--original-corollary-bg);
     --corollary-body-bg: var(--original-corollary-bg);
-    // --corollary-body-text: var(--original-corollary-text); // No longer used
     --corollary-outer-border: var(--original-corollary-border);
 
     // Lemma
     --lemma-title-bg: var(--original-lemma-text);
     --lemma-title-text: var(--original-lemma-bg);
     --lemma-body-bg: var(--original-lemma-bg);
-    // --lemma-body-text: var(--original-lemma-text); // No longer used
     --lemma-outer-border: var(--original-lemma-border);
 
     // Axiom
     --axiom-title-bg: var(--original-axiom-text);
     --axiom-title-text: var(--original-axiom-bg);
     --axiom-body-bg: var(--original-axiom-bg);
-    // --axiom-body-text: var(--original-axiom-text); // No longer used
     --axiom-outer-border: var(--original-axiom-border);
 
     // Definition
     --definition-title-bg: var(--original-definition-text);
     --definition-title-text: var(--original-definition-bg);
     --definition-body-bg: var(--original-definition-bg);
-    // --definition-body-text: var(--original-definition-text); // No longer used
     --definition-outer-border: var(--original-definition-border);
 
     // Proof
     --proof-title-bg: var(--original-proof-text);
     --proof-title-text: var(--original-proof-bg);
     --proof-body-bg: var(--original-proof-bg);
-    // --proof-body-text: var(--original-proof-text); // No longer used
     --proof-outer-border: var(--original-proof-border);
     --proof-qed-color: var(--original-proof-qed-color);
+}
+
+/* DARK THEME Overrides */
+:root[dark] {
+    --math-body-text-color-default: var(--math-body-text-color-default-dark);
+
+    // Theorem
+    --theorem-title-bg: var(--original-theorem-text-dark); // Light pastel for title BG
+    --theorem-title-text: var(--original-theorem-bg-dark);   // Dark pastel for title text
+    --theorem-body-bg: var(--original-theorem-bg-dark);      // Dark pastel for body BG
+    --theorem-outer-border: var(--original-theorem-border-dark);
+
+    // Postulate
+    --postulate-title-bg: var(--original-postulate-text-dark);
+    --postulate-title-text: var(--original-postulate-bg-dark);
+    --postulate-body-bg: var(--original-postulate-bg-dark);
+    --postulate-outer-border: var(--original-postulate-border-dark);
+
+    // Corollary
+    --corollary-title-bg: var(--original-corollary-text-dark);
+    --corollary-title-text: var(--original-corollary-bg-dark);
+    --corollary-body-bg: var(--original-corollary-bg-dark);
+    --corollary-outer-border: var(--original-corollary-border-dark);
+
+    // Lemma
+    --lemma-title-bg: var(--original-lemma-text-dark);
+    --lemma-title-text: var(--original-lemma-bg-dark);
+    --lemma-body-bg: var(--original-lemma-bg-dark);
+    --lemma-outer-border: var(--original-lemma-border-dark);
+
+    // Axiom
+    --axiom-title-bg: var(--original-axiom-text-dark);
+    --axiom-title-text: var(--original-axiom-bg-dark);
+    --axiom-body-bg: var(--original-axiom-bg-dark);
+    --axiom-outer-border: var(--original-axiom-border-dark);
+
+    // Definition
+    --definition-title-bg: var(--original-definition-text-dark);
+    --definition-title-text: var(--original-definition-bg-dark);
+    --definition-body-bg: var(--original-definition-bg-dark);
+    --definition-outer-border: var(--original-definition-border-dark);
+
+    // Proof
+    --proof-title-bg: var(--original-proof-text-dark);
+    --proof-title-text: var(--original-proof-bg-dark);
+    --proof-body-bg: var(--original-proof-bg-dark);
+    --proof-outer-border: var(--original-proof-border-dark);
+    --proof-qed-color: var(--original-proof-qed-color-dark);
 }
 
 /* General Math Block Styling */
 .math-block {
     margin: var(--math-block-margin);
     border-radius: var(--math-block-border-radius);
-    // border-style: solid; /* This is the outer border */
-    border-width: var(--math-block-border-width); /* This is the outer border */
+    border-width: var(--math-block-border-width);
     font-family: var(--math-block-font-family);
     position: relative;
     overflow: hidden;
+    //border-style: solid;
 }
 
 .math-block-title {
@@ -122,8 +200,7 @@
 .math-block-body {
     padding: var(--math-body-padding);
     line-height: 1.6;
-    color: var(--math-body-text-color-default); /* Body text is now always this color */
-    /* The .math-block-body itself does not have a border */
+    color: var(--math-body-text-color-default);
 }
 
 /* QED symbol for proofs */
@@ -143,10 +220,6 @@
 }
 
 /* Apply specific colors per type */
-/* The outer border is set on .math-block directly. */
-/* Title and Body backgrounds and Title text color are set here. */
-/* Body text color is now globally set to --math-body-text-color-default. */
-
 .theorem {
     border-color: var(--theorem-outer-border);
     .math-block-title {
@@ -155,7 +228,6 @@
     }
     .math-block-body {
         background-color: var(--theorem-body-bg);
-        /* color: var(--theorem-body-text); // This line is removed */
     }
 }
 
@@ -222,6 +294,5 @@
     }
     .math-block-body {
         background-color: var(--proof-body-bg);
-        /* QED symbol color is handled by --proof-qed-color */
     }
 }


### PR DESCRIPTION
En este PR se incluye soporte para la creacion de bloques matemáticos:

- definiciones (bloque `definition`)
- axiomas (bloque `axiom`)
- postulados (bloque `postulate`)
- teoremas (bloque `theorem`)
- corolarios (bloque `corollary`)
- lemas (bloque `lemma`)
- demostraciones (bloque `proof`)

Además, se incluye soporte para referenciar un bloque definido previamente.

Por ejemplo:

```text
{% theorem title="Teorema de Pitágoras" label=th-pitagoras %}
Definir teorema aquí.
{% endtheorem%}
```

El bloque se puede referenciar luego usando el comando `{% block_ref etiqueta%}`. Por ejemplo.

> De acuerdo con el {% block_ref th-pitagoras %} podemos ver que...
